### PR TITLE
fixes for 0.6: eachline, isxdigit

### DIFF
--- a/src/TOML.jl
+++ b/src/TOML.jl
@@ -2,6 +2,10 @@ __precompile__(true)
 
 module TOML
 
+    if VERSION < v"0.6-"
+        eachline(args...; chomp=false) = (@assert !chomp; Base.eachline(args...))
+    end
+
     include("parser.jl")
     include("print.jl")
 

--- a/src/parser.jl
+++ b/src/parser.jl
@@ -67,7 +67,7 @@ function linecol(p::Parser, offset::Int)
     seekstart(p.input)
     line = 0
     cur = 1
-    for (i,l) in enumerate(readlines(p.input))
+    for (i,l) in enumerate(eachline(p.input, chomp=false))
         if cur + length(l) > offset
             return (i, offset - cur + 1)
         end
@@ -570,7 +570,7 @@ function escape(p::Parser, st::Int, multiline::Bool)
                     error(p, st, st+len, "expected $len hex digits after a `$ch` escape")
                     thorw()
                 end
-                if !isxdigit(snum)
+                if !all(isxdigit, snum)
                     error(p, st, st+len, "unknown string escape: `$snum`")
                     thorw()
                 end

--- a/src/print.jl
+++ b/src/print.jl
@@ -2,7 +2,7 @@
 isbare(c::Char) = 'A' <= c <= 'Z' || 'a' <= c <= 'z' || isdigit(c) || c == '-' || c == '_'
 
 function printkey(io::IO, keys::Vector{String})
-    for (i,k) in enumerate(keys)
+    for (i, k) in enumerate(keys)
         i != 1 && Base.print(io, ".")
         if length(k) == 0
             # empty key
@@ -21,12 +21,12 @@ function printvalue(io::IO, value; sorted=false)
         _print(io, value, sorted=sorted)
     elseif isa(value, Array)
         Base.print(io, "[")
-        for (i, e) in enumerate(value)
+        for (i, x) in enumerate(value)
             i != 1 && Base.print(io, ", ")
-            if isa(e, Associative)
-                _print(io, e, sorted=sorted)
+            if isa(x, Associative)
+                _print(io, x, sorted=sorted)
             else
-                printvalue(io, e, sorted=sorted)
+                printvalue(io, x, sorted=sorted)
             end
         end
         Base.print(io, "]")
@@ -40,12 +40,13 @@ function printvalue(io::IO, value; sorted=false)
 end
 
 function _print(io::IO, a::Associative, ks=String[]; sorted=false)
-  akeys = keys(a)
-  if sorted
-      akeys = sort!(collect(akeys))
-  end
+    akeys = keys(a)
+    if sorted
+        akeys = sort!(collect(akeys))
+    end
+    first_block = true
 
-  for key in akeys
+    for key in akeys
         value = a[key]
         # skip tables
         isa(value, Associative) && continue # skip tables
@@ -56,12 +57,15 @@ function _print(io::IO, a::Associative, ks=String[]; sorted=false)
         Base.print(io, " = ") # print separator
         printvalue(io, value, sorted=sorted)
         Base.print(io, "\n")  # new line?
+        first_block = false
     end
 
     for key in akeys
         value = a[key]
         if isa(value, Associative)
             # print table
+            first_block || println(io)
+            first_block = false
             push!(ks, key)
             Base.print(io,"[")
             printkey(io, ks)
@@ -70,6 +74,8 @@ function _print(io::IO, a::Associative, ks=String[]; sorted=false)
             pop!(ks)
         elseif isa(value, Array) && length(value)>0 && isa(value[1], Associative)
             # print array of tables
+            first_block || println(io)
+            first_block = false
             push!(ks, key)
             for v in value
                 Base.print(io,"[[")

--- a/src/print.jl
+++ b/src/print.jl
@@ -53,6 +53,7 @@ function _print(io::IO, a::Associative, ks=String[]; sorted=false)
         # skip arrays of tabels
         isa(value, Array) && length(value)>0 && isa(value[1], Associative) && continue
 
+        Base.print(io, repeat("    ", max(0, length(ks)-1)))
         printkey(io, [key])
         Base.print(io, " = ") # print separator
         printvalue(io, value, sorted=sorted)
@@ -60,6 +61,7 @@ function _print(io::IO, a::Associative, ks=String[]; sorted=false)
         first_block = false
     end
 
+    indent = repeat("    ", length(ks))
     for key in akeys
         value = a[key]
         if isa(value, Associative)
@@ -67,6 +69,7 @@ function _print(io::IO, a::Associative, ks=String[]; sorted=false)
             first_block || println(io)
             first_block = false
             push!(ks, key)
+            Base.print(io, indent)
             Base.print(io,"[")
             printkey(io, ks)
             Base.print(io,"]\n")
@@ -78,6 +81,7 @@ function _print(io::IO, a::Associative, ks=String[]; sorted=false)
             first_block = false
             push!(ks, key)
             for v in value
+                Base.print(io, indent)
                 Base.print(io,"[[")
                 printkey(io, ks)
                 Base.print(io,"]]\n")


### PR DESCRIPTION
* eachline now defaults to chomping lines
* isxdigit for strings is deprecated