### PR TITLE
Parse readable datetime format

### DIFF
--- a/src/TOML.jl
+++ b/src/TOML.jl
@@ -1,7 +1,7 @@
 module TOML
 
     import Dates
-    
+
     include("parser.jl")
     include("print.jl")
 

--- a/src/parser.jl
+++ b/src/parser.jl
@@ -103,10 +103,10 @@ function peek(p::Parser)
 end
 
 "Returns `true` and consumes the next character if it matches `ch`, otherwise do nothing and return `false`"
-function consume(p::Parser, ch::AbstractChar)
+function consume(p::Parser, ch::AbstractChar...)
     eof(p) && return false
     c = peek(p)
-    if get(c) == ch
+    if get(c) in ch
         read(p)
         return true
     else
@@ -425,7 +425,7 @@ function datetime(p::Parser, syear::String, st::Integer)
     month,  valid = parsetwodigits(p, valid)
     valid = valid && consume(p, '-')
     day,    valid = parsetwodigits(p, valid)
-    valid = valid && consume(p, 'T')
+    valid = valid && consume(p, 't', 'T', ' ')
     hour,   valid = parsetwodigits(p, valid)
     valid = valid && consume(p, ':')
     minute, valid = parsetwodigits(p, valid)
@@ -460,7 +460,7 @@ function datetime(p::Parser, syear::String, st::Integer)
     tzplus = true
     tzminus = false
     tzsign = true
-    if valid && !consume(p, 'Z')
+    if valid && !consume(p, 'Z', 'z')
         tzplus = consume(p, '+')
         if !tzplus
             tzminus = consume(p, '-')

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -358,6 +358,8 @@ trimmed in raw strings.
     @testset "Datetime" begin
 
         @testval("2016-09-09T09:09:09Z", Dates.DateTime(2016,9,9,9,9,9))
+        @testval("2016-09-09 09:09:09Z", Dates.DateTime(2016,9,9,9,9,9))
+        @testval("2016-09-09t09:09:09z", Dates.DateTime(2016,9,9,9,9,9))
         @testval("2016-09-09T09:09:09.0Z", Dates.DateTime(2016,9,9,9,9,9))
         @testval("2016-09-09T09:09:09.0+10:00", Dates.DateTime(2016,9,9,19,9,9))
         @testval("2016-09-09T09:09:09.012-02:00", Dates.DateTime(2016,9,9,7,9,9,12))
@@ -367,6 +369,8 @@ trimmed in raw strings.
         @fail("foo = 2016-09-09T09:09:09+2:00", "malformed date literal")
         @fail("foo = 2016-09-09T09:09:09-2:00", "malformed date literal")
         @fail("foo = 2016-09-09T09:09:09Z-2:00", "expected a newline after a key")
+        @fail("foo = 2016-09-09s09:09:09Z", "malformed date literal")
+        @fail("foo = 2016-09-09 09:09:09x", "malformed date literal")
 
     end
 


### PR DESCRIPTION
According to RFC 3339 'T' and 'Z' character can be of lower case, and 'T' substituted to space. See notes of https://tools.ietf.org/html/rfc3339#section-5.6.

Related to #12 