### PR TITLE
separate `error` from `Base.error`

### DIFF
--- a/src/parser.jl
+++ b/src/parser.jl
@@ -48,7 +48,7 @@ mutable struct Parser{IO_T<:IO}
     Parser(input::IO_T) where {IO_T <: IO}  = new{IO_T}(input, ParserError[], IOBuffer(), ' ')
 end
 Parser(input::String) = Parser(IOBuffer(input))
-Base.error(p::Parser, l, h, msg) = push!(p.errors, ParserError(l, h, msg))
+error(p::Parser, l, h, msg) = push!(p.errors, ParserError(l, h, msg))
 Base.eof(p::Parser) = eof(p.input)
 Base.position(p::Parser) = position(p.input)+1
 Base.write(p::Parser, x) = write(p.charbuffer, x)

--- a/src/print.jl
+++ b/src/print.jl
@@ -93,7 +93,7 @@ function _print(io::IO, a::AbstractDict,
                 Base.print(io,"[[")
                 printkey(io, ks)
                 Base.print(io,"]]\n")
-                !isa(v, AbstractDict) && error("array should contain only tables")
+                !isa(v, AbstractDict) && Base.error("array should contain only tables")
                 _print(io, v, ks, indent=indent+1, sorted=sorted, by=by)
             end
             pop!(ks)


### PR DESCRIPTION
I don't think this is the same function as `Base.error` --- in particular, it doesn't throw, which is a major difference.